### PR TITLE
Fix blue/red artifacting in some rectangles on mac VNC connection

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -335,6 +335,10 @@ export default class Display {
                 'color': color
             });
         } else {
+            // For Virtualization server, swap R and B channels
+            if (this._isVirtualizationServer) {
+                color = [color[2], color[1], color[0]];
+            }
             this._setFillColor(color);
             this._drawCtx.fillRect(x, y, width, height);
             this._damage(x, y, width, height);


### PR DESCRIPTION
Fixes an issue with BGRA -> RGBA color switching. Mac VNC connection sends color data in a different order than novnc typically expects. This has been mostly patched in trycua/novnc but there was still some artifacting. This PR fixes this.