### PR TITLE
Add noVNC session recorder

### DIFF
--- a/app/images/record.svg
+++ b/app/images/record.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="25"
+   height="25"
+   viewBox="0 0 25 25"
+   version="1.1">
+  <circle
+     cx="12.5"
+     cy="12.5"
+     r="8"
+     style="fill:#ffffff;fill-opacity:1;stroke:none" />
+</svg>

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -605,6 +605,22 @@ html {
     max-height: calc(100vh - 10em - 25px);
 }
 
+/* Recording */
+#noVNC_record_button.noVNC_recording {
+    border-color: #ff4444;
+    background-color: rgba(255, 68, 68, 0.3);
+}
+#noVNC_record_button.noVNC_recording img {
+    filter: brightness(0) saturate(100%) invert(35%) sepia(100%) saturate(3000%) hue-rotate(340deg) brightness(100%) contrast(100%);
+}
+#noVNC_record p {
+    margin: 5px 0;
+}
+#noVNC_record input[type=button] {
+    width: 100%;
+    margin-top: 5px;
+}
+
 /* Settings */
 #noVNC_settings {
 }

--- a/demo_collector.html
+++ b/demo_collector.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demonstration Collector</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #1a1a2e;
+            color: #eee;
+            min-height: 100vh;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        h1 {
+            margin-bottom: 10px;
+            color: #fff;
+        }
+        .subtitle {
+            color: #888;
+            margin-bottom: 40px;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            width: 100%;
+            max-width: 400px;
+        }
+        button {
+            padding: 20px 40px;
+            font-size: 18px;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-weight: 600;
+        }
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .collect-btn {
+            background: #4CAF50;
+            color: white;
+        }
+        .collect-btn:hover:not(:disabled) {
+            background: #45a049;
+            transform: translateY(-2px);
+        }
+        .collect-btn.recording {
+            background: #f44336;
+            animation: pulse 1.5s infinite;
+        }
+        .download-btn {
+            background: #2196F3;
+            color: white;
+        }
+        .download-btn:hover:not(:disabled) {
+            background: #1976D2;
+            transform: translateY(-2px);
+        }
+        .status {
+            text-align: center;
+            padding: 15px;
+            background: #252540;
+            border-radius: 8px;
+            min-height: 80px;
+        }
+        .status-label {
+            color: #888;
+            font-size: 12px;
+            text-transform: uppercase;
+            margin-bottom: 8px;
+        }
+        .status-value {
+            font-size: 16px;
+            font-family: monospace;
+        }
+        .storage-info {
+            font-size: 12px;
+            color: #666;
+            margin-top: 10px;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.7; }
+        }
+        .config {
+            background: #252540;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 10px;
+        }
+        .config label {
+            display: block;
+            margin-bottom: 8px;
+            color: #888;
+            font-size: 12px;
+            text-transform: uppercase;
+        }
+        .config input {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #444;
+            border-radius: 4px;
+            background: #1a1a2e;
+            color: #fff;
+            font-size: 14px;
+        }
+        .config input:focus {
+            outline: none;
+            border-color: #4CAF50;
+        }
+    </style>
+</head>
+<body>
+    <h1>Demonstration Collector</h1>
+    <p class="subtitle">Record VNC sessions for training data</p>
+
+    <div class="container">
+        <div class="config">
+            <label>VNC URL (host:port)</label>
+            <input type="text" id="vncUrl" placeholder="localhost:6081" value="localhost:6081">
+        </div>
+        <div class="config">
+            <label>VNC Password (optional)</label>
+            <input type="password" id="vncPassword" placeholder="Leave empty if none">
+        </div>
+
+        <button class="collect-btn" id="collectBtn" onclick="toggleCollection()">
+            Collect Demonstration
+        </button>
+
+        <button class="download-btn" id="downloadBtn" onclick="downloadDemo()">
+            Download Demonstration
+        </button>
+
+        <div class="status">
+            <div class="status-label">Status</div>
+            <div class="status-value" id="statusText">Ready</div>
+            <div class="storage-info" id="storageInfo"></div>
+        </div>
+    </div>
+
+    <script>
+        let vncWindow = null;
+        let isCollecting = false;
+        let statusCheckInterval = null;
+
+        // Update storage info on load and periodically
+        updateStorageInfo();
+        setInterval(updateStorageInfo, 2000);
+
+        async function updateStorageInfo() {
+            const storageElem = document.getElementById('storageInfo');
+            try {
+                const s = await navigator.storage.estimate();
+                const usageGB = (s.usage / 1e9).toFixed(3);
+                const quotaGB = (s.quota / 1e9).toFixed(1);
+                storageElem.textContent = `Storage: ${usageGB}GB / ${quotaGB}GB`;
+
+                // Also check if there's a recording file
+                await checkRecordingFile();
+            } catch (e) {
+                storageElem.textContent = 'Storage: unavailable';
+            }
+        }
+
+        async function checkRecordingFile() {
+            const downloadBtn = document.getElementById('downloadBtn');
+            const statusText = document.getElementById('statusText');
+
+            try {
+                const root = await navigator.storage.getDirectory();
+                const fileHandle = await root.getFileHandle('vnc-recording.bin');
+                const file = await fileHandle.getFile();
+
+                if (file.size > 0 && !isCollecting) {
+                    const sizeMB = (file.size / (1024 * 1024)).toFixed(2);
+                    downloadBtn.disabled = false;
+                    if (!isCollecting) {
+                        statusText.textContent = `Recording available: ${sizeMB} MB`;
+                    }
+                }
+            } catch (e) {
+                // No recording file exists
+                if (!isCollecting) {
+                    downloadBtn.disabled = true;
+                }
+            }
+        }
+
+        function toggleCollection() {
+            if (isCollecting) {
+                stopCollection();
+            } else {
+                startCollection();
+            }
+        }
+
+        function startCollection() {
+            const vncUrl = document.getElementById('vncUrl').value || 'localhost:6081';
+            const password = document.getElementById('vncPassword').value;
+
+            // Parse host and port
+            const [host, port] = vncUrl.includes(':') ? vncUrl.split(':') : [vncUrl, '6081'];
+
+            // Build the vnc.html URL with autoconnect and autorecord
+            let url = `vnc.html?host=${encodeURIComponent(host)}&port=${encodeURIComponent(port)}&autoconnect=1&autorecord=1`;
+            if (password) {
+                url += `&password=${encodeURIComponent(password)}`;
+            }
+
+            // Open in a popup window (PiP-like)
+            const width = 1024;
+            const height = 768;
+            const left = window.screen.width - width - 50;
+            const top = 50;
+
+            vncWindow = window.open(
+                url,
+                'vnc_demo',
+                `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=no`
+            );
+
+            if (vncWindow) {
+                isCollecting = true;
+                updateUI();
+
+                // Monitor if window is closed
+                statusCheckInterval = setInterval(() => {
+                    if (vncWindow.closed) {
+                        stopCollection();
+                    }
+                }, 500);
+            } else {
+                alert('Failed to open VNC window. Please allow popups for this site.');
+            }
+        }
+
+        function stopCollection() {
+            isCollecting = false;
+
+            if (statusCheckInterval) {
+                clearInterval(statusCheckInterval);
+                statusCheckInterval = null;
+            }
+
+            if (vncWindow && !vncWindow.closed) {
+                vncWindow.close();
+            }
+            vncWindow = null;
+
+            updateUI();
+
+            // Wait a moment for OPFS to sync, then check for file
+            setTimeout(updateStorageInfo, 500);
+        }
+
+        function updateUI() {
+            const collectBtn = document.getElementById('collectBtn');
+            const downloadBtn = document.getElementById('downloadBtn');
+            const statusText = document.getElementById('statusText');
+
+            if (isCollecting) {
+                collectBtn.textContent = 'Stop Collection';
+                collectBtn.classList.add('recording');
+                downloadBtn.disabled = true;
+                statusText.textContent = 'Recording in progress...';
+            } else {
+                collectBtn.textContent = 'Collect Demonstration';
+                collectBtn.classList.remove('recording');
+                statusText.textContent = 'Ready';
+            }
+        }
+
+        async function downloadDemo() {
+            const statusText = document.getElementById('statusText');
+            statusText.textContent = 'Preparing download...';
+
+            try {
+                const root = await navigator.storage.getDirectory();
+                const fileHandle = await root.getFileHandle('vnc-recording.bin');
+                const file = await fileHandle.getFile();
+
+                if (file.size === 0) {
+                    statusText.textContent = 'No recording data found';
+                    return;
+                }
+
+                statusText.textContent = 'Converting to playback format...';
+
+                // Convert binary OPFS format to JS playback format
+                const jsContent = await convertToPlaybackFormat(file);
+
+                // Download as .js file
+                const blob = new Blob([jsContent], { type: 'application/javascript' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `demo_${new Date().toISOString().replace(/[:.]/g, '-')}.js`;
+                a.click();
+                URL.revokeObjectURL(url);
+
+                statusText.textContent = 'Download complete!';
+
+                // Ask if user wants to clear the recording
+                if (confirm('Download complete! Clear the recording to free up storage?')) {
+                    await clearRecording();
+                }
+            } catch (e) {
+                console.error('Download error:', e);
+                statusText.textContent = 'Error: ' + e.message;
+            }
+        }
+
+        async function convertToPlaybackFormat(file) {
+            const statusText = document.getElementById('statusText');
+            const totalSize = file.size;
+
+            console.log('Converting file, size:', totalSize);
+
+            if (totalSize === 0) {
+                throw new Error('Recording file is empty');
+            }
+
+            // Read entire file into memory (simpler than chunked approach)
+            const buffer = await file.arrayBuffer();
+            const view = new DataView(buffer);
+            let pos = 0;
+            let frames = [];
+            let frameCount = 0;
+
+            while (pos + 9 <= buffer.byteLength) {
+                const fromClient = view.getUint8(pos) === 1;
+                const timestamp = view.getUint32(pos + 1, false);  // big endian
+                const dataLen = view.getUint32(pos + 5, false);    // big endian
+
+                console.log(`Frame ${frameCount}: fromClient=${fromClient}, timestamp=${timestamp}, dataLen=${dataLen}, pos=${pos}`);
+
+                if (dataLen > 100 * 1024 * 1024) {
+                    // Sanity check - frame shouldn't be larger than 100MB
+                    throw new Error(`Invalid frame at pos ${pos}: dataLen=${dataLen} is too large`);
+                }
+
+                if (pos + 9 + dataLen > buffer.byteLength) {
+                    console.warn(`Truncated frame at pos ${pos}, needed ${dataLen} bytes but only ${buffer.byteLength - pos - 9} available`);
+                    break;
+                }
+
+                const data = new Uint8Array(buffer, pos + 9, dataLen);
+
+                // Convert to base64
+                let binary = '';
+                for (let i = 0; i < data.length; i++) {
+                    binary += String.fromCharCode(data[i]);
+                }
+                const base64 = btoa(binary);
+
+                // Format: "{timestamp{base64data" for server, "}timestamp{base64data" for client
+                const prefix = fromClient ? '}' : '{';
+                frames.push(`"${prefix}${timestamp}{${base64}"`);
+
+                pos += 9 + dataLen;
+                frameCount++;
+
+                // Update status every 100 frames
+                if (frameCount % 100 === 0) {
+                    const percent = ((pos / totalSize) * 100).toFixed(0);
+                    statusText.textContent = `Converting: ${percent}% (${frameCount} frames)`;
+                    // Yield to UI
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+
+            console.log(`Conversion complete: ${frameCount} frames`);
+            frames.push('"EOF"');
+
+            return `/* Recorded VNC session - ${new Date().toISOString()} */\n` +
+                   `/* ${frameCount} frames, ${(file.size / 1024 / 1024).toFixed(2)} MB */\n` +
+                   `var VNC_frame_data = [\n${frames.join(',\n')}\n];\n`;
+        }
+
+        async function clearRecording() {
+            try {
+                const root = await navigator.storage.getDirectory();
+                await root.removeEntry('vnc-recording.bin');
+                document.getElementById('statusText').textContent = 'Recording cleared';
+                document.getElementById('downloadBtn').disabled = true;
+                await updateStorageInfo();
+            } catch (e) {
+                console.error('Clear error:', e);
+            }
+        }
+
+        // Handle page unload
+        window.addEventListener('beforeunload', () => {
+            if (vncWindow && !vncWindow.closed) {
+                vncWindow.close();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tests/benchmark_buffer.html
+++ b/tests/benchmark_buffer.html
@@ -1,0 +1,736 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Recording Buffer Benchmark</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 900px;
+            margin: 40px auto;
+            padding: 20px;
+            background: #1a1a2e;
+            color: #eee;
+        }
+        h1 { color: #00d4ff; }
+        .config {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .config label {
+            display: block;
+            margin-bottom: 10px;
+        }
+        .config input[type="number"] {
+            width: 100px;
+            padding: 8px;
+            border: none;
+            border-radius: 4px;
+            background: #0f3460;
+            color: #fff;
+        }
+        .methods {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+        .method {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            border: 2px solid #0f3460;
+        }
+        .method h3 {
+            margin-top: 0;
+            color: #00d4ff;
+        }
+        .method p {
+            font-size: 0.9em;
+            color: #aaa;
+            margin-bottom: 15px;
+        }
+        button {
+            background: #e94560;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            margin-right: 10px;
+            margin-bottom: 10px;
+        }
+        button:hover { background: #ff6b6b; }
+        button:disabled {
+            background: #555;
+            cursor: not-allowed;
+        }
+        .status {
+            margin-top: 10px;
+            padding: 10px;
+            background: #0f3460;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 12px;
+            min-height: 60px;
+            white-space: pre-wrap;
+        }
+        .progress {
+            height: 20px;
+            background: #0f3460;
+            border-radius: 4px;
+            margin-top: 10px;
+            overflow: hidden;
+        }
+        .progress-bar {
+            height: 100%;
+            background: linear-gradient(90deg, #00d4ff, #e94560);
+            width: 0%;
+            transition: width 0.1s;
+        }
+        #results {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-top: 20px;
+        }
+        #results h3 { color: #00d4ff; margin-top: 0; }
+        #resultsTable {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        #resultsTable th, #resultsTable td {
+            padding: 10px;
+            text-align: left;
+            border-bottom: 1px solid #0f3460;
+        }
+        #resultsTable th { color: #00d4ff; }
+        .success { color: #4ade80; }
+        .failure { color: #f87171; }
+    </style>
+</head>
+<body>
+    <h1>Recording Buffer Benchmark</h1>
+    <p>Test different storage methods for high-throughput VNC recording (~10MB/s)</p>
+
+    <div class="config">
+        <label>
+            Target data size (GB):
+            <input type="number" id="targetGB" value="0.5" min="0.1" max="10" step="0.1">
+        </label>
+        <label>
+            Simulated throughput (MB/s):
+            <input type="number" id="throughputMB" value="10" min="1" max="100" step="1">
+        </label>
+        <label>
+            Chunk size (KB):
+            <input type="number" id="chunkKB" value="64" min="1" max="1024" step="1">
+        </label>
+    </div>
+
+    <div class="methods">
+        <!-- Method 1: In-memory array -->
+        <div class="method">
+            <h3>1. In-Memory Array</h3>
+            <p>Current approach: Push Uint8Array chunks to a JavaScript array. Simple but memory-heavy.</p>
+            <button onclick="runBenchmark('memory')">Run Test</button>
+            <button onclick="stopBenchmark('memory')">Stop</button>
+            <button onclick="downloadData_('memory')" id="download-memory" disabled>Download</button>
+            <button onclick="clearData('memory')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-memory"></div></div>
+            <div class="status" id="status-memory">Ready</div>
+        </div>
+
+        <!-- Method 2: Pre-allocated ArrayBuffer -->
+        <div class="method">
+            <h3>2. Pre-allocated Buffer</h3>
+            <p>Allocate a large ArrayBuffer upfront and write into it. Avoids repeated allocations.</p>
+            <button onclick="runBenchmark('preallocated')">Run Test</button>
+            <button onclick="stopBenchmark('preallocated')">Stop</button>
+            <button onclick="downloadData_('preallocated')" id="download-preallocated" disabled>Download</button>
+            <button onclick="clearData('preallocated')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-preallocated"></div></div>
+            <div class="status" id="status-preallocated">Ready</div>
+        </div>
+
+        <!-- Method 3: Chunked arrays -->
+        <div class="method">
+            <h3>3. Chunked Arrays (64MB blocks)</h3>
+            <p>Store data in fixed-size 64MB ArrayBuffers. Balances memory efficiency with GC pressure.</p>
+            <button onclick="runBenchmark('chunked')">Run Test</button>
+            <button onclick="stopBenchmark('chunked')">Stop</button>
+            <button onclick="downloadData_('chunked')" id="download-chunked" disabled>Download</button>
+            <button onclick="clearData('chunked')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-chunked"></div></div>
+            <div class="status" id="status-chunked">Ready</div>
+        </div>
+
+        <!-- Method 4: File System Access API -->
+        <div class="method">
+            <h3>4. File Stream (OPFS)</h3>
+            <p>Stream to Origin Private File System. Keeps memory low but requires async writes.</p>
+            <button onclick="runBenchmark('opfs')">Run Test</button>
+            <button onclick="stopBenchmark('opfs')">Stop</button>
+            <button onclick="downloadData_('opfs')" id="download-opfs" disabled>Download</button>
+            <button onclick="clearData('opfs')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-opfs"></div></div>
+            <div class="status" id="status-opfs">Ready</div>
+        </div>
+
+        <!-- Method 5: IndexedDB -->
+        <div class="method">
+            <h3>5. IndexedDB Chunks</h3>
+            <p>Store chunks in IndexedDB. Persistent storage with automatic memory management.</p>
+            <button onclick="runBenchmark('indexeddb')">Run Test</button>
+            <button onclick="stopBenchmark('indexeddb')">Stop</button>
+            <button onclick="downloadData_('indexeddb')" id="download-indexeddb" disabled>Download</button>
+            <button onclick="clearData('indexeddb')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-indexeddb"></div></div>
+            <div class="status" id="status-indexeddb">Ready</div>
+        </div>
+
+        <!-- Method 6: Blob accumulation -->
+        <div class="method">
+            <h3>6. Blob Accumulation</h3>
+            <p>Periodically merge chunks into Blobs. Leverages browser's blob storage.</p>
+            <button onclick="runBenchmark('blob')">Run Test</button>
+            <button onclick="stopBenchmark('blob')">Stop</button>
+            <button onclick="downloadData_('blob')" id="download-blob" disabled>Download</button>
+            <button onclick="clearData('blob')">Clear</button>
+            <div class="progress"><div class="progress-bar" id="progress-blob"></div></div>
+            <div class="status" id="status-blob">Ready</div>
+        </div>
+    </div>
+
+    <div id="results">
+        <h3>Results</h3>
+        <table id="resultsTable">
+            <thead>
+                <tr>
+                    <th>Method</th>
+                    <th>Status</th>
+                    <th>Data Written</th>
+                    <th>Time</th>
+                    <th>Throughput</th>
+                    <th>Peak Memory</th>
+                </tr>
+            </thead>
+            <tbody id="resultsBody">
+            </tbody>
+        </table>
+    </div>
+
+    <script>
+        const benchmarks = {};
+        const results = [];
+        const downloadData = {};  // Store data for download after each test
+
+        function getConfig() {
+            return {
+                targetBytes: parseFloat(document.getElementById('targetGB').value) * 1024 * 1024 * 1024,
+                throughputBytesPerSec: parseFloat(document.getElementById('throughputMB').value) * 1024 * 1024,
+                chunkSize: parseFloat(document.getElementById('chunkKB').value) * 1024
+            };
+        }
+
+        function updateStatus(method, text) {
+            document.getElementById(`status-${method}`).textContent = text;
+        }
+
+        function updateProgress(method, percent) {
+            document.getElementById(`progress-${method}`).style.width = `${percent}%`;
+        }
+
+        function formatBytes(bytes) {
+            if (bytes >= 1024 * 1024 * 1024) return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+            if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(2) + ' MB';
+            if (bytes >= 1024) return (bytes / 1024).toFixed(2) + ' KB';
+            return bytes + ' B';
+        }
+
+        function getMemoryUsage() {
+            if (performance.memory) {
+                return performance.memory.usedJSHeapSize;
+            }
+            return null;
+        }
+
+        function addResult(method, status, bytesWritten, timeMs, peakMemory) {
+            const throughput = timeMs > 0 ? (bytesWritten / (timeMs / 1000)) : 0;
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${method}</td>
+                <td class="${status === 'Success' ? 'success' : 'failure'}">${status}</td>
+                <td>${formatBytes(bytesWritten)}</td>
+                <td>${(timeMs / 1000).toFixed(2)}s</td>
+                <td>${formatBytes(throughput)}/s</td>
+                <td>${peakMemory ? formatBytes(peakMemory) : 'N/A'}</td>
+            `;
+            document.getElementById('resultsBody').appendChild(row);
+        }
+
+        function stopBenchmark(method) {
+            if (benchmarks[method]) {
+                benchmarks[method].stopped = true;
+            }
+        }
+
+        async function clearData(method) {
+            const data = downloadData[method];
+            if (data) {
+                // Special cleanup for persistent storage
+                if (data.type === 'opfs') {
+                    try {
+                        const root = await navigator.storage.getDirectory();
+                        await root.removeEntry('benchmark.bin');
+                    } catch (e) { /* ignore */ }
+                } else if (data.type === 'indexeddb') {
+                    await new Promise((resolve) => {
+                        const req = indexedDB.deleteDatabase(data.dbName);
+                        req.onsuccess = resolve;
+                        req.onerror = resolve;
+                    });
+                }
+            }
+
+            delete downloadData[method];
+            disableDownload(method);
+            updateStatus(method, 'Data cleared');
+            updateProgress(method, 0);
+        }
+
+        function enableDownload(method) {
+            document.getElementById(`download-${method}`).disabled = false;
+        }
+
+        function disableDownload(method) {
+            document.getElementById(`download-${method}`).disabled = true;
+        }
+
+        async function downloadData_(method) {
+            const data = downloadData[method];
+            if (!data) {
+                alert('No data available for download');
+                return;
+            }
+
+            updateStatus(method, 'Preparing download...');
+
+            try {
+                let blob;
+                const startTime = performance.now();
+
+                switch (data.type) {
+                    case 'array':
+                        // Array of Uint8Arrays
+                        updateStatus(method, `Creating blob from ${data.chunks.length} chunks...`);
+                        blob = new Blob(data.chunks, { type: 'application/octet-stream' });
+                        break;
+
+                    case 'buffer':
+                        // Single ArrayBuffer
+                        updateStatus(method, `Creating blob from buffer (${formatBytes(data.buffer.byteLength)})...`);
+                        blob = new Blob([data.buffer], { type: 'application/octet-stream' });
+                        break;
+
+                    case 'chunked':
+                        // Array of ArrayBuffers (blocks)
+                        updateStatus(method, `Creating blob from ${data.blocks.length} blocks...`);
+                        blob = new Blob(data.blocks, { type: 'application/octet-stream' });
+                        break;
+
+                    case 'opfs':
+                        // Read from OPFS
+                        updateStatus(method, 'Reading from OPFS...');
+                        const root = await navigator.storage.getDirectory();
+                        const fileHandle = await root.getFileHandle('benchmark.bin');
+                        const file = await fileHandle.getFile();
+                        blob = file;
+                        break;
+
+                    case 'indexeddb':
+                        // Read from IndexedDB
+                        updateStatus(method, 'Reading from IndexedDB...');
+                        blob = await readIndexedDBAsBlob(data.dbName, data.storeName);
+                        break;
+
+                    case 'blob':
+                        // Already a blob
+                        blob = data.blob;
+                        break;
+
+                    default:
+                        throw new Error('Unknown data type');
+                }
+
+                const prepTime = performance.now() - startTime;
+                updateStatus(method, `Download ready (prep took ${(prepTime/1000).toFixed(2)}s)\nSize: ${formatBytes(blob.size)}`);
+
+                // Trigger download
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `benchmark-${method}-${formatBytes(blob.size).replace(' ', '')}.bin`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+
+                // Revoke after a delay to ensure download starts
+                setTimeout(() => URL.revokeObjectURL(url), 10000);
+
+            } catch (e) {
+                updateStatus(method, `Download error: ${e.message}`);
+            }
+        }
+
+        async function readIndexedDBAsBlob(dbName, storeName) {
+            const db = await new Promise((resolve, reject) => {
+                const req = indexedDB.open(dbName, 1);
+                req.onerror = () => reject(req.error);
+                req.onsuccess = () => resolve(req.result);
+            });
+
+            const chunks = await new Promise((resolve, reject) => {
+                const tx = db.transaction(storeName, 'readonly');
+                const store = tx.objectStore(storeName);
+                const req = store.getAll();
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => reject(req.error);
+            });
+
+            db.close();
+            return new Blob(chunks, { type: 'application/octet-stream' });
+        }
+
+        async function runBenchmark(method) {
+            const config = getConfig();
+            const state = {
+                stopped: false,
+                bytesWritten: 0,
+                startTime: performance.now(),
+                peakMemory: getMemoryUsage() || 0
+            };
+            benchmarks[method] = state;
+
+            updateStatus(method, 'Starting...');
+            updateProgress(method, 0);
+
+            // Generate a chunk of random-ish data (simulating VNC frame data)
+            const chunk = new Uint8Array(config.chunkSize);
+            for (let i = 0; i < chunk.length; i++) {
+                chunk[i] = Math.floor(Math.random() * 256);
+            }
+
+            try {
+                switch (method) {
+                    case 'memory':
+                        await benchmarkMemory(state, config, chunk);
+                        break;
+                    case 'preallocated':
+                        await benchmarkPreallocated(state, config, chunk);
+                        break;
+                    case 'chunked':
+                        await benchmarkChunked(state, config, chunk);
+                        break;
+                    case 'opfs':
+                        await benchmarkOPFS(state, config, chunk);
+                        break;
+                    case 'indexeddb':
+                        await benchmarkIndexedDB(state, config, chunk);
+                        break;
+                    case 'blob':
+                        await benchmarkBlob(state, config, chunk);
+                        break;
+                }
+
+                const elapsed = performance.now() - state.startTime;
+                if (state.stopped) {
+                    addResult(method, 'Stopped', state.bytesWritten, elapsed, state.peakMemory);
+                } else {
+                    addResult(method, 'Success', state.bytesWritten, elapsed, state.peakMemory);
+                }
+                updateStatus(method, `Complete: ${formatBytes(state.bytesWritten)} in ${(elapsed/1000).toFixed(2)}s`);
+
+            } catch (e) {
+                const elapsed = performance.now() - state.startTime;
+                addResult(method, `Failed: ${e.message}`, state.bytesWritten, elapsed, state.peakMemory);
+                updateStatus(method, `Error: ${e.message}`);
+            }
+
+            updateProgress(method, 100);
+        }
+
+        // Method 1: Simple in-memory array
+        async function benchmarkMemory(state, config, chunk) {
+            disableDownload('memory');
+            const frames = [];
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                frames.push(chunk.slice()); // Copy the chunk
+                state.bytesWritten += chunk.length;
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('memory', progress);
+                    updateStatus('memory', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}\nFrames: ${frames.length}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+
+                    // Yield to browser
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+
+            // Store for download
+            downloadData['memory'] = { type: 'array', chunks: frames };
+            enableDownload('memory');
+        }
+
+        // Method 2: Pre-allocated ArrayBuffer
+        async function benchmarkPreallocated(state, config, chunk) {
+            disableDownload('preallocated');
+            updateStatus('preallocated', 'Allocating buffer...');
+
+            // Try to allocate the full buffer
+            let buffer;
+            try {
+                buffer = new ArrayBuffer(config.targetBytes);
+            } catch (e) {
+                throw new Error(`Failed to allocate ${formatBytes(config.targetBytes)}: ${e.message}`);
+            }
+
+            const view = new Uint8Array(buffer);
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+            let offset = 0;
+
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                const remaining = config.targetBytes - offset;
+                const writeSize = Math.min(chunk.length, remaining);
+                view.set(chunk.subarray(0, writeSize), offset);
+                offset += writeSize;
+                state.bytesWritten = offset;
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('preallocated', progress);
+                    updateStatus('preallocated', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+
+            // Store for download (trim to actual bytes written if stopped early)
+            downloadData['preallocated'] = { type: 'buffer', buffer: buffer.slice(0, state.bytesWritten) };
+            enableDownload('preallocated');
+        }
+
+        // Method 3: Chunked arrays (64MB blocks)
+        async function benchmarkChunked(state, config, chunk) {
+            disableDownload('chunked');
+            const BLOCK_SIZE = 64 * 1024 * 1024; // 64MB blocks
+            const blocks = [];
+            let currentBlock = new Uint8Array(BLOCK_SIZE);
+            let blockOffset = 0;
+
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                const remaining = BLOCK_SIZE - blockOffset;
+
+                if (remaining >= chunk.length) {
+                    currentBlock.set(chunk, blockOffset);
+                    blockOffset += chunk.length;
+                } else {
+                    // Fill current block and start new one
+                    currentBlock.set(chunk.subarray(0, remaining), blockOffset);
+                    blocks.push(currentBlock);
+
+                    currentBlock = new Uint8Array(BLOCK_SIZE);
+                    blockOffset = chunk.length - remaining;
+                    currentBlock.set(chunk.subarray(remaining), 0);
+                }
+
+                state.bytesWritten += chunk.length;
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('chunked', progress);
+                    updateStatus('chunked', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}\nBlocks: ${blocks.length + 1}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+
+            // Add final partial block (trimmed to actual size)
+            if (blockOffset > 0) {
+                blocks.push(currentBlock.slice(0, blockOffset));
+            }
+
+            // Store for download
+            downloadData['chunked'] = { type: 'chunked', blocks: blocks };
+            enableDownload('chunked');
+        }
+
+        // Method 4: Origin Private File System
+        async function benchmarkOPFS(state, config, chunk) {
+            disableDownload('opfs');
+            if (!navigator.storage || !navigator.storage.getDirectory) {
+                throw new Error('OPFS not supported in this browser');
+            }
+
+            const root = await navigator.storage.getDirectory();
+            const fileHandle = await root.getFileHandle('benchmark.bin', { create: true });
+            const writable = await fileHandle.createWritable();
+
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                await writable.write(chunk);
+                state.bytesWritten += chunk.length;
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('opfs', progress);
+                    updateStatus('opfs', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+                }
+            }
+
+            await writable.close();
+
+            // Keep file for download (don't delete)
+            downloadData['opfs'] = { type: 'opfs' };
+            enableDownload('opfs');
+        }
+
+        // Method 5: IndexedDB
+        async function benchmarkIndexedDB(state, config, chunk) {
+            disableDownload('indexeddb');
+            const dbName = 'benchmark_db';
+            const storeName = 'chunks';
+
+            // Delete existing database
+            await new Promise((resolve, reject) => {
+                const req = indexedDB.deleteDatabase(dbName);
+                req.onsuccess = resolve;
+                req.onerror = resolve; // Ignore errors
+            });
+
+            // Create database
+            const db = await new Promise((resolve, reject) => {
+                const req = indexedDB.open(dbName, 1);
+                req.onerror = () => reject(req.error);
+                req.onsuccess = () => resolve(req.result);
+                req.onupgradeneeded = (e) => {
+                    e.target.result.createObjectStore(storeName, { autoIncrement: true });
+                };
+            });
+
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+            const BATCH_SIZE = 100; // Write in batches for better performance
+
+            let batch = [];
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                batch.push(chunk.slice());
+                state.bytesWritten += chunk.length;
+
+                if (batch.length >= BATCH_SIZE || i === chunksNeeded - 1) {
+                    // Write batch to IndexedDB
+                    await new Promise((resolve, reject) => {
+                        const tx = db.transaction(storeName, 'readwrite');
+                        const store = tx.objectStore(storeName);
+                        for (const item of batch) {
+                            store.add(item);
+                        }
+                        tx.oncomplete = resolve;
+                        tx.onerror = () => reject(tx.error);
+                    });
+                    batch = [];
+                }
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('indexeddb', progress);
+                    updateStatus('indexeddb', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+                }
+            }
+
+            db.close();
+
+            // Keep database for download (don't delete)
+            downloadData['indexeddb'] = { type: 'indexeddb', dbName, storeName };
+            enableDownload('indexeddb');
+        }
+
+        // Method 6: Blob accumulation
+        async function benchmarkBlob(state, config, chunk) {
+            disableDownload('blob');
+            const MERGE_THRESHOLD = 10 * 1024 * 1024; // Merge every 10MB
+            let pendingChunks = [];
+            let pendingSize = 0;
+            let blobs = [];
+
+            const chunksNeeded = Math.ceil(config.targetBytes / config.chunkSize);
+            const updateInterval = Math.max(1, Math.floor(chunksNeeded / 100));
+
+            for (let i = 0; i < chunksNeeded && !state.stopped; i++) {
+                pendingChunks.push(chunk.slice());
+                pendingSize += chunk.length;
+                state.bytesWritten += chunk.length;
+
+                // Periodically merge into a blob
+                if (pendingSize >= MERGE_THRESHOLD) {
+                    const blob = new Blob(pendingChunks, { type: 'application/octet-stream' });
+                    blobs.push(blob);
+                    pendingChunks = [];
+                    pendingSize = 0;
+                }
+
+                if (i % updateInterval === 0) {
+                    const progress = (state.bytesWritten / config.targetBytes) * 100;
+                    updateProgress('blob', progress);
+                    updateStatus('blob', `Writing: ${formatBytes(state.bytesWritten)} / ${formatBytes(config.targetBytes)}\nBlobs: ${blobs.length}`);
+
+                    const mem = getMemoryUsage();
+                    if (mem) state.peakMemory = Math.max(state.peakMemory, mem);
+
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+
+            // Final merge
+            if (pendingChunks.length > 0) {
+                blobs.push(new Blob(pendingChunks, { type: 'application/octet-stream' }));
+            }
+
+            // Create final blob (for download capability)
+            const finalBlob = new Blob(blobs, { type: 'application/octet-stream' });
+            updateStatus('blob', `Complete: ${formatBytes(state.bytesWritten)}\nFinal blob: ${formatBytes(finalBlob.size)}`);
+
+            // Store for download
+            downloadData['blob'] = { type: 'blob', blob: finalBlob };
+            enableDownload('blob');
+        }
+    </script>
+</body>
+</html>

--- a/utils/novnc_proxy
+++ b/utils/novnc_proxy
@@ -34,12 +34,15 @@ usage() {
     echo "    --heartbeat SEC       send a ping to the client every SEC seconds"
     echo "    --timeout SEC         after SEC seconds exit when not connected"
     echo "    --idle-timeout SEC    server exits after SEC seconds if there are no"
+    echo "                          active connections"
     echo "                                    "
     echo "    --web-auth            enable authentication"
     echo "    --auth-plugin CLASS   authentication plugin to use"
     echo "    --auth-source ARG     plugin configuration"
     echo "                                    "
-    echo "                          active connections"
+    echo "    --password PASS       VNC password (passed to vnc.html URL)"
+    echo "    --autoconnect         auto-connect on page load"
+    echo "    --autorecord          auto-record on page load"
     echo "                                    "
     exit 2
 }
@@ -65,6 +68,9 @@ WEBAUTH_ARG=""
 AUTHPLUGIN_ARG=""
 AUTHSOURCE_ARG=""
 FILEONLY_ARG=""
+VNC_PASSWORD=""
+AUTOCONNECT=""
+AUTORECORD=""
 
 
 die() {
@@ -103,6 +109,9 @@ while [ "$*" ]; do
     --web-auth) WEBAUTH_ARG="--web-auth"                ;;
     --auth-plugin) AUTHPLUGIN_ARG="--auth-plugin ${OPTARG}"; shift ;;
     --auth-source) AUTHSOURCE_ARG="--auth-source ${OPTARG}"; shift ;;
+    --password) VNC_PASSWORD="${OPTARG}"; shift ;;
+    --autoconnect) AUTOCONNECT="1" ;;
+    --autorecord) AUTORECORD="1" ;;
     -h|--help) usage                              ;;
     -*) usage "Unknown chrooter option: ${param}" ;;
     *) break                                      ;;
@@ -223,10 +232,14 @@ if [ -z "$HOST" ]; then
 fi
 
 echo -e "\n\nNavigate to this URL:\n"
+URL_PARAMS="host=${HOST}&port=${PORT}"
+[ -n "$VNC_PASSWORD" ] && URL_PARAMS="${URL_PARAMS}&password=${VNC_PASSWORD}"
+[ -n "$AUTOCONNECT" ] && URL_PARAMS="${URL_PARAMS}&autoconnect=1"
+[ -n "$AUTORECORD" ] && URL_PARAMS="${URL_PARAMS}&autorecord=1"
 if [ "x$SSLONLY" == "x" ]; then
-    echo -e "    http://${HOST}:${PORT}/vnc.html?host=${HOST}&port=${PORT}\n"
+    echo -e "    http://${HOST}:${PORT}/vnc.html?${URL_PARAMS}\n"
 else
-    echo -e "    https://${HOST}:${PORT}/vnc.html?host=${HOST}&port=${PORT}\n"
+    echo -e "    https://${HOST}:${PORT}/vnc.html?${URL_PARAMS}\n"
 fi
 
 echo -e "Press Ctrl-C to exit\n\n"

--- a/utils/novnc_proxy
+++ b/utils/novnc_proxy
@@ -42,7 +42,12 @@ usage() {
     echo "                                    "
     echo "    --password PASS       VNC password (passed to vnc.html URL)"
     echo "    --autoconnect         auto-connect on page load"
-    echo "    --autorecord          auto-record on page load"
+    echo "    --autorecord          auto-record on page load (local OPFS storage)"
+    echo "                                    "
+    echo "    --record-server       start recording server for external recording"
+    echo "    --record-port PORT    recording server port (default: 6090)"
+    echo "    --record-output FILE  recording output file (default: recording.bin)"
+    echo "    --record-js           also convert recording to JS format"
     echo "                                    "
     exit 2
 }
@@ -71,6 +76,11 @@ FILEONLY_ARG=""
 VNC_PASSWORD=""
 AUTOCONNECT=""
 AUTORECORD=""
+RECORD_SERVER=""
+RECORD_PORT="6090"
+RECORD_OUTPUT="recording.bin"
+RECORD_JS=""
+recording_server_pid=""
 
 
 die() {
@@ -82,6 +92,10 @@ cleanup() {
     trap - TERM QUIT INT EXIT
     trap "true" CHLD   # Ignore cleanup messages
     echo
+    if [ -n "${recording_server_pid}" ]; then
+        echo "Terminating recording server (${recording_server_pid})"
+        kill ${recording_server_pid} 2>/dev/null
+    fi
     if [ -n "${proxy_pid}" ]; then
         echo "Terminating WebSockets proxy (${proxy_pid})"
         kill ${proxy_pid}
@@ -112,6 +126,10 @@ while [ "$*" ]; do
     --password) VNC_PASSWORD="${OPTARG}"; shift ;;
     --autoconnect) AUTOCONNECT="1" ;;
     --autorecord) AUTORECORD="1" ;;
+    --record-server) RECORD_SERVER="1" ;;
+    --record-port) RECORD_PORT="${OPTARG}"; shift ;;
+    --record-output) RECORD_OUTPUT="${OPTARG}"; shift ;;
+    --record-js) RECORD_JS="1" ;;
     -h|--help) usage                              ;;
     -*) usage "Unknown chrooter option: ${param}" ;;
     *) break                                      ;;
@@ -216,6 +234,28 @@ WEB=`realpath "${WEB}"`
 [ -n "${CERT}" ] && CERT=`realpath "${CERT}"`
 [ -n "${KEY}" ] && KEY=`realpath "${KEY}"`
 [ -n "${RECORD}" ] && RECORD=`realpath "${RECORD}"`
+[ -n "${RECORD_OUTPUT}" ] && RECORD_OUTPUT=`realpath "${RECORD_OUTPUT}"`
+
+# Start recording server if requested
+if [ -n "${RECORD_SERVER}" ]; then
+    RECORD_SCRIPT="${HERE}/recording_server.py"
+    if [ ! -f "${RECORD_SCRIPT}" ]; then
+        die "Recording server script not found: ${RECORD_SCRIPT}"
+    fi
+
+    echo "Starting recording server on port ${RECORD_PORT}..."
+    RECORD_JS_ARG=""
+    [ -n "${RECORD_JS}" ] && RECORD_JS_ARG="--js"
+    python3 "${RECORD_SCRIPT}" --port "${RECORD_PORT}" --output "${RECORD_OUTPUT}" ${RECORD_JS_ARG} &
+    recording_server_pid="$!"
+    sleep 1
+
+    if [ -z "$recording_server_pid" ] || ! ps -eo pid= | grep -w "$recording_server_pid" > /dev/null; then
+        recording_server_pid=
+        die "Failed to start recording server"
+    fi
+    echo "Recording server started (PID: ${recording_server_pid})"
+fi
 
 echo "Starting webserver and WebSockets proxy on${HOST:+ host ${HOST}} port ${PORT}"
 ${WEBSOCKIFY} ${SYSLOG_ARG} ${SSLONLY} ${FILEONLY_ARG} --web ${WEB} ${CERT:+--cert ${CERT}} ${KEY:+--key ${KEY}} ${LISTEN} ${VNC_DEST} ${HEARTBEAT_ARG} ${IDLETIMEOUT_ARG} ${RECORD:+--record ${RECORD}} ${TIMEOUT_ARG} ${WEBAUTH_ARG} ${AUTHPLUGIN_ARG} ${AUTHSOURCE_ARG} &
@@ -236,6 +276,11 @@ URL_PARAMS="host=${HOST}&port=${PORT}"
 [ -n "$VNC_PASSWORD" ] && URL_PARAMS="${URL_PARAMS}&password=${VNC_PASSWORD}"
 [ -n "$AUTOCONNECT" ] && URL_PARAMS="${URL_PARAMS}&autoconnect=1"
 [ -n "$AUTORECORD" ] && URL_PARAMS="${URL_PARAMS}&autorecord=1"
+# If recording server is running, add record_url (autorecord must also be set for streaming)
+if [ -n "$RECORD_SERVER" ]; then
+    RECORD_URL="ws://${HOST}:${RECORD_PORT}"
+    URL_PARAMS="${URL_PARAMS}&record_url=${RECORD_URL}&autorecord=1"
+fi
 if [ "x$SSLONLY" == "x" ]; then
     echo -e "    http://${HOST}:${PORT}/vnc.html?${URL_PARAMS}\n"
 else

--- a/utils/recording_server.py
+++ b/utils/recording_server.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+VNC Recording Server
+
+A WebSocket server that receives VNC recording frames from noVNC
+and saves them to a file.
+
+Usage:
+    python recording_server.py [--port PORT] [--output FILE]
+
+    --port PORT     Port to listen on (default: 6090)
+    --output FILE   Output file path (default: recording.bin)
+    --js            Also convert to JS playback format when done
+
+Example:
+    python recording_server.py --port 6090 --output demo.bin --js
+
+Then in noVNC, use:
+    vnc.html?host=...&autoconnect=1&autorecord=1&record_url=ws://localhost:6090
+"""
+
+import argparse
+import asyncio
+import base64
+import signal
+import struct
+import sys
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import websockets
+except ImportError:
+    print("Error: websockets library not found. Install with: pip install websockets")
+    sys.exit(1)
+
+
+class RecordingServer:
+    def __init__(self, output_path: str, convert_to_js: bool = False):
+        self.output_path = Path(output_path)
+        self.convert_to_js = convert_to_js
+        self.file = None
+        self.frame_count = 0
+        self.bytes_written = 0
+        self.client_connected = False
+        self.start_time = None
+
+    async def handle_client(self, websocket):
+        """Handle a single WebSocket client connection."""
+        if self.client_connected:
+            print("Warning: Another client is already connected, rejecting new connection")
+            await websocket.close(1008, "Another client already connected")
+            return
+
+        self.client_connected = True
+        self.frame_count = 0
+        self.bytes_written = 0
+        self.start_time = datetime.now()
+
+        # Open output file
+        self.file = open(self.output_path, 'wb')
+
+        client_addr = websocket.remote_address
+        print(f"[{self.start_time.strftime('%H:%M:%S')}] Client connected from {client_addr}")
+        print(f"Recording to: {self.output_path}")
+
+        try:
+            async for message in websocket:
+                if isinstance(message, bytes):
+                    self.file.write(message)
+                    self.frame_count += 1
+                    self.bytes_written += len(message)
+
+                    # Progress update every 1000 frames
+                    if self.frame_count % 1000 == 0:
+                        mb = self.bytes_written / (1024 * 1024)
+                        print(f"  Received {self.frame_count} frames ({mb:.2f} MB)")
+
+        except websockets.exceptions.ConnectionClosed as e:
+            print(f"Connection closed: {e.code} {e.reason}")
+        finally:
+            self.file.close()
+            self.client_connected = False
+
+            duration = (datetime.now() - self.start_time).total_seconds()
+            mb = self.bytes_written / (1024 * 1024)
+            print(f"Recording complete: {self.frame_count} frames, {mb:.2f} MB in {duration:.1f}s")
+
+            if self.convert_to_js:
+                await self.convert_to_js_format()
+
+    async def convert_to_js_format(self):
+        """Convert binary recording to JS playback format."""
+        js_path = self.output_path.with_suffix('.js')
+        print(f"Converting to JS format: {js_path}")
+
+        frames = []
+        with open(self.output_path, 'rb') as f:
+            while True:
+                header = f.read(9)
+                if len(header) < 9:
+                    break
+
+                from_client = header[0] == 1
+                timestamp = struct.unpack('>I', header[1:5])[0]  # big endian
+                data_len = struct.unpack('>I', header[5:9])[0]   # big endian
+
+                data = f.read(data_len)
+                if len(data) < data_len:
+                    print(f"Warning: Truncated frame, expected {data_len} bytes, got {len(data)}")
+                    break
+
+                # Convert to base64
+                b64_data = base64.b64encode(data).decode('ascii')
+
+                # Format: "{timestamp{base64data" for server, "}timestamp{base64data" for client
+                prefix = '}' if from_client else '{'
+                frame_str = f'{prefix}{timestamp}{{{b64_data}'
+                frames.append(f'"{frame_str}"')
+
+        frames.append('"EOF"')
+
+        # Write JS file
+        with open(js_path, 'w') as f:
+            f.write(f'/* Recorded VNC session - {datetime.now().isoformat()} */\n')
+            f.write(f'/* {len(frames) - 1} frames */\n')
+            f.write('var VNC_frame_data = [\n')
+            f.write(',\n'.join(frames))
+            f.write('\n];\n')
+
+        print(f"JS conversion complete: {js_path}")
+
+
+async def main():
+    parser = argparse.ArgumentParser(description='VNC Recording Server')
+    parser.add_argument('--port', type=int, default=6090, help='Port to listen on (default: 6090)')
+    parser.add_argument('--output', type=str, default='recording.bin', help='Output file path')
+    parser.add_argument('--js', action='store_true', help='Convert to JS format when recording ends')
+    parser.add_argument('--host', type=str, default='0.0.0.0', help='Host to bind to (default: 0.0.0.0)')
+    args = parser.parse_args()
+
+    server = RecordingServer(args.output, convert_to_js=args.js)
+
+    # Handle graceful shutdown
+    stop_event = asyncio.Event()
+
+    def signal_handler():
+        print("\nShutting down...")
+        stop_event.set()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, signal_handler)
+
+    print(f"VNC Recording Server")
+    print(f"====================")
+    print(f"Listening on ws://{args.host}:{args.port}")
+    print(f"Output file: {args.output}")
+    print(f"JS conversion: {'enabled' if args.js else 'disabled'}")
+    print()
+    print("Use in noVNC with URL parameter:")
+    print(f"  record_url=ws://localhost:{args.port}")
+    print()
+    print("Press Ctrl+C to stop")
+    print()
+
+    async with websockets.serve(server.handle_client, args.host, args.port):
+        await stop_event.wait()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/vnc.html
+++ b/vnc.html
@@ -190,6 +190,24 @@
             </div>
             </div>
 
+            <!-- Record session -->
+            <input type="image" alt="Record" src="app/images/record.svg"
+                id="noVNC_record_button" class="noVNC_button"
+                title="Record session">
+            <div class="noVNC_vcenter">
+            <div id="noVNC_record" class="noVNC_panel">
+                <div class="noVNC_heading">
+                    <img alt="" src="app/images/record.svg"> Recording
+                </div>
+                <p id="noVNC_record_status">Not recording</p>
+                <p id="noVNC_record_stats"></p>
+                <p id="noVNC_record_storage"></p>
+                <input type="button" id="noVNC_record_start_button" value="Start Recording">
+                <input type="button" id="noVNC_record_stop_button" value="Stop Recording" disabled>
+                <input type="button" id="noVNC_record_download_button" value="Download" disabled>
+            </div>
+            </div>
+
             <!-- Toggle fullscreen -->
             <input type="image" alt="Full screen" src="app/images/fullscreen.svg"
                 id="noVNC_fullscreen_button" class="noVNC_button noVNC_hidden"


### PR DESCRIPTION
## Summary

This PR adds client-side session recording to the noVNC HTML5 web client. When recording, it streams captured websocket data to a .bin file using the Origin Private File System (OPFS) API. When exporting, this data is processed in chunks and streamed to the output file. This allows for long running recordings up to 20GB (only tested up to this amount) with low memory overhead.

## New URL Parameters

| Parameter | Description | Example |
|-----------|-------------|---------|
| `autorecord` | Automatically queue recording on page load. Recording starts when connection is established. | `autorecord=1` |
| `record_url` | WebSocket URL to stream recording data to an external server instead of local OPFS storage. Enables integration with Python SDK and agent clients. | `record_url=ws://localhost:6090` |

## New novnc_proxy Flags

| Flag | Description |
|------|-------------|
| `--autorecord` | Auto-record on page load (uses local OPFS storage) |
| `--record-server` | Start the Python recording server for external streaming |
| `--record-port PORT` | Recording server port (default: 6090) |
| `--record-output FILE` | Recording output file path (default: recording.bin) |
| `--record-js` | Also convert recording to JS playback format when complete |

## Example Usage for Demonstration Collection Workflows

### 1. Manual Recording (UI Button)
Click the record button in the control bar, connect to VNC, perform actions, stop recording, and download.

### 2. Automated Local Recording
```bash
./utils/novnc_proxy --vnc localhost:5900 --listen localhost:6081 \
    --password mypass --autoconnect --autorecord
```
Recording is stored in browser OPFS and can be downloaded via the UI.

### 3. External Recording Server (Recommended for Automation)
```bash
./utils/novnc_proxy --vnc localhost:5900 --listen localhost:6081 \
    --password mypass --autoconnect \
    --record-server --record-output demo.bin --record-js
```
Recording streams directly to disk via Python WebSocket server. File is ready immediately when session ends.

### 4. Standalone Recording Server (Python/Shell Integration)
```bash
# Terminal 1: Start recording server
python3 utils/recording_server.py --port 6090 --output session.bin --js

# Terminal 2: Open browser with recording URL
open "http://localhost:6081/vnc.html?host=localhost&port=6081&autoconnect=1&autorecord=1&record_url=ws://localhost:6090"
```

### 5. Demo Collector UI (Example)
A standalone `demo_collector.html` page provides a simple two-button interface:
- **Collect Demonstration** - Opens VNC in a popup with auto-record enabled
- **Download Demonstration** - Exports the recorded session

```
http://localhost:6081/demo_collector.html
```

## New Files
- `utils/recording_server.py` - Python WebSocket server for receiving streamed recordings
- `demo_collector.html` - Standalone demonstration collection interface

<img width="1382" height="1026" alt="image" src="https://github.com/user-attachments/assets/379a5d57-4560-4a07-8416-458652c2a967" />
